### PR TITLE
Update spec with latest v2 changes

### DIFF
--- a/v2/v2-specification.md
+++ b/v2/v2-specification.md
@@ -1023,7 +1023,7 @@ bytes32 msgHash = keccak256(abi.encodePacked(ETH_PERSONAL_MESSAGE, hash));
 
 ### Wallet
 
-The `Wallet` signature type allows a contract to trade on behalf of any other address(es) by defining it's own signature validation function. When used with order signing, the `Wallet` contract _is_ the `maker` of the order and should hold any assets that will be traded. This contract should have the following interface:
+The `Wallet` signature type allows a contract to trade on behalf of any other address(es) by defining its own signature validation function. When used with order signing, the `Wallet` contract _is_ the `maker` of the order and should hold any assets that will be traded. When using this signature type, the [`Exchange`](#exchange) contract makes a `STATICCALL` to the `Wallet` contract's `isValidSignature` method, which means that signature verifcation will fail and revert if the `Wallet` attempts to update state. This contract should have the following interface:
 
 ```
 contract IWallet {
@@ -1092,7 +1092,7 @@ contract IValidator {
 }
 ```
 
-The signature is validated by calling the `Validator` contract's `isValidSignature` method.
+The signature is validated by calling the `Validator` contract's `isValidSignature` method. When using this signature type, the [`Exchange`](#exchange) contract makes a `STATICCALL` to the `Validator` contract's `isValidSignature` method, which means that signature verifcation will fail and revert if the `Validator` attempts to update state.
 
 ```
 // Pop last 20 bytes off of signature byte array.
@@ -1103,7 +1103,8 @@ if (!allowedValidators[signerAddress][validatorAddress]) {
     return false;
 }
 
-isValid = IValidator(validatorAddress).isValidSignature(
+isValid = isValidValidatorSignature(
+    validatorAddress,
     hash,
     signerAddress,
     signature
@@ -1118,7 +1119,7 @@ Allows any address to sign a hash on-chain by calling the `preSign` method on th
 // Mapping of hash => signer => signed
 mapping (bytes32 => mapping(address => bool)) public preSigned;
 
-/// @dev Approves a hash on-chain using any valid signature type.
+/// @dev Approves a hash on-chain using any valid signature type or `msg.sender`.
 ///      After presigning a hash, the preSign signature type will become valid for that hash and signer.
 /// @param signerAddress Address that should have signed the given hash.
 /// @param signature Proof that the hash has been signed by signer.

--- a/v2/v2-specification.md
+++ b/v2/v2-specification.md
@@ -665,6 +665,20 @@ function getOrderInfo(Order memory order)
     returns (OrderInfo memory orderInfo);
 ```
 
+### getOrdersInfo
+
+`getOrdersInfo` calls [`getOrderInfo`](#getorderinfo) sequentially for each provided order.
+
+```
+/// @dev Fetches information for all passed in orders.
+/// @param orders Array of order specifications.
+/// @return Array of OrderInfo instances that correspond to each order.
+function getOrdersInfo(LibOrder.Order[] memory orders)
+    public
+    view
+    returns (LibOrder.OrderInfo[] memory);
+```
+
 # Transactions
 
 Transaction messages exist for the purpose of calling methods on the [`Exchange`](#exchange) contract in the context of another address (see [ZEIP18](https://github.com/0xProject/ZEIPs/issues/18)). This is especially useful for implementing [filter contracts](#filter-contracts).

--- a/v2/v2-specification.md
+++ b/v2/v2-specification.md
@@ -252,18 +252,18 @@ An order message consists of the following parameters:
 | [makerAssetData](#assetdata)    | bytes   | ABIv2 encoded data that can be decoded by a specified proxy contract when transferring makerAsset.                                              |
 | [takerAssetData](#assetdata)    | bytes   | ABIv2 encoded data that can be decoded by a specified proxy contract when transferring takerAsset.                                              |
 
-### SenderAddress
+### senderAddress
 
 If the `senderAddress` of an order is not set to 0, only that address may call [`Exchange`](#exchange) contract methods that affect that order. See the [filter contracts examples](#filter-contracts) for more information.
 
-### Salt
+### salt
 
 An order's `salt` parameter has two main usecases:
 
 - To ensure uniqueness within an order's hash.
-- To be used in combination with [`cancelOrdersUpTo`](#cancelordersupto). To get the most benefit of this usecase, it is recommended that the `salt` field be treated as a timestamp for when orders have been created. A timestamp in milliseconds would allow a maker to create 1000 orders with the same parameters per second.
+- To be used in combination with [`cancelOrdersUpTo`](#cancelordersupto). When creating an order, the `salt` value _should_ be equal to the value of the current timestamp in milliseconds. This allows maker to create 1000 orders with the same parameters per second. Note that although this is part of the protocol specification, there is currently no way to enforce this usage and `salt` values should _not_ be relied upon as a surce of truth.
 
-### AssetData
+### assetData
 
 The `makerAssetData` and `takerAssetData` fields of an order contain information specific to that asset. These fields are encoded using [ABIv2](http://solidity.readthedocs.io/en/latest/abi-spec.html) with a 4 byte id that references the proxy that is intended to decode the data. See the [`ERC20Proxy`](#erc20proxy) and [`ERC721Proxy`](#erc721proxy) sections for the layouts of the `assetData` fields for each `AssetProxy` contract.
 

--- a/v2/v2-specification.md
+++ b/v2/v2-specification.md
@@ -970,11 +970,9 @@ All signatures submitted to the Exchange contract are represented as a byte arra
 | 0x01           | [Invalid](#invalid)     |
 | 0x02           | [EIP712](#eip712)       |
 | 0x03           | [EthSign](#ethsign)     |
-| 0x04           | [Caller](#caller)       |
-| 0x05           | [Wallet](#wallet)       |
-| 0x06           | [Validator](#validator) |
-| 0x07           | [PreSigned](#presigned) |
-| 0x08           | [Trezor](#trezor)       |
+| 0x04           | [Wallet](#wallet)       |
+| 0x05           | [Validator](#validator) |
+| 0x06           | [PreSigned](#presigned) |
 
 ### Illegal
 
@@ -1006,10 +1004,6 @@ bytes32 msgHash = keccak256(abi.encodePacked(ETH_PERSONAL_MESSAGE, hash));
 ```
 
 `v`, `r`, and `s` are encoded in the signature byte array using the same scheme as [EIP712 signatures](#EIP712).
-
-### Caller
-
-This signature type will consider the signer to be the sender of the current message call (i.e `msg.sender`).
 
 ### Wallet
 
@@ -1126,19 +1120,6 @@ The hash can then be validated with only a `PreSigned` signature byte by checkin
 isValid = preSigned[hash][signerAddress];
 return isValid;
 ```
-
-### Trezor
-
-This signature type allows for compatability with Trezor hardware wallets, which use a non-standard encoding when adding a prefix to the hash being signed. A `Trezor` signature is considered valid if the address recovered from calling `ecrecover` with the a Trezor-prefixed hash and decoded `v`, `r`, `s` values is the same as the specified signer.
-
-The prefixed `msgHash` is calculated with:
-
-```
-string constant TREZOR_PERSONAL_MESSAGE = "\x19Ethereum Signed Message:\n\x20";
-bytes32 msgHash = keccak256(abi.encodePacked(TREZOR_PERSONAL_MESSAGE, hash));
-```
-
-`v`, `r`, and `s` are encoded in the signature byte array using the same scheme as [EIP712 signatures](#EIP712).
 
 # Events
 

--- a/v2/v2-specification.md
+++ b/v2/v2-specification.md
@@ -31,6 +31,7 @@
     1.  [AssetProxy events](#assetproxy-events)
     1.  [AssetProxyOwner events](#assetproxyowner-events)
 1.  [Types](#types)
+1.  [Standard relayer API](#standard-relayer-api)
 1.  [Miscellaneous](#miscellaneous)
     1.  [EIP712 usage](#eip712-usage)
     1.  [Optimizing calldata](#optimizing-calldata)
@@ -1327,6 +1328,10 @@ struct OrderInfo {
     uint256 orderTakerAssetFilledAmount;  // Amount of order that has already been filled.
 }
 ```
+
+# Standard relayer API
+
+For a full specification of how orders are intended to be posted to and retrieved from relayers, see the [SRA v2 specification](https://github.com/0xProject/standard-relayer-api#sra-v2).
 
 # Miscellaneous
 

--- a/v2/v2-specification.md
+++ b/v2/v2-specification.md
@@ -34,6 +34,7 @@
 1.  [Miscellaneous](#miscellaneous)
     1.  [EIP712 usage](#eip712-usage)
     1.  [Optimizing calldata](#optimizing-calldata)
+    1.  [ecrecover usage](#ecrecover-usage)
 
 # Architecture
 
@@ -984,17 +985,17 @@ An `Invalid` signature always returns false. An invalid signature can always be 
 
 ### EIP712
 
-An `EIP712` signature is considered valid if the address recovered from calling `ecrecover` with the given hash and decoded `v`, `r`, `s` values is the same as the specified signer. In this case, the signature is encoded in the following way:
+An `EIP712` signature is considered valid if the address recovered from calling [`ecrecover`](#ecrecover-usage) with the given hash and decoded `v`, `r`, `s` values is the same as the specified signer. In this case, the signature is encoded in the following way:
 
-| Offset | Length | Contents |
-| ------ | ------ | -------- |
-| 0x00   | 1      | v        |
-| 0x01   | 32     | r        |
-| 0x21   | 32     | s        |
+| Offset | Length | Contents            |
+| ------ | ------ | ------------------- |
+| 0x00   | 1      | v (always 27 or 28) |
+| 0x01   | 32     | r                   |
+| 0x21   | 32     | s                   |
 
 ### EthSign
 
-An `EthSign` signature is considered valid if the address recovered from calling `ecrecover` with the an EthSign-prefixed hash and decoded `v`, `r`, `s` values is the same as the specified signer.
+An `EthSign` signature is considered valid if the address recovered from calling [`ecrecover`](#ecrecover-usage) with the an EthSign-prefixed hash and decoded `v`, `r`, `s` values is the same as the specified signer.
 
 The prefixed `msgHash` is calculated with:
 
@@ -1365,3 +1366,7 @@ The [`matchOrders`](#matchorders), [`marketSellOrders`](#marketsellorders), [`ma
 ### Vanity addresses
 
 If frequently trading from a single address, it may make sense to generate a vanity address with as many zero bytes as possible.
+
+## ecrecover usage
+
+The `ecrecover` precompile available in Solidity expects `v` to always have a value of `27` or `28`. Some signers and clients assume that `v` will have a value of `0` or `1`, so it may be necessary to add `27` to `v` before submitting it to the `Exchange` contract.


### PR DESCRIPTION
- Removes `Caller` and `Trezor` signature types
- Clarifies `v` value for `ecrecover`(#7 )
- Specifies how `salt` should be used
- Adds note on reentrancy
- Adds `getOrdersInfo` section
- Adds `STATICCALL` clarification to `Wallet` and `Validator` signature types
- Adds section on SRA