### PR TITLE
Remove trailing comma from EIP712_ORDER_SCHEMA_HASH

### DIFF
--- a/v2/v2-specification.md
+++ b/v2/v2-specification.md
@@ -289,7 +289,7 @@ bytes32 constant EIP712_ORDER_SCHEMA_HASH = keccak256(abi.encodePacked(
     "uint256 expirationTimeSeconds,",
     "uint256 salt,",
     "bytes makerAssetData,",
-    "bytes takerAssetData,",
+    "bytes takerAssetData",
     ")"
 ));
 


### PR DESCRIPTION
The comma removed here is not present in the 0x.js implementation
or the contract implementation of this value, so I'm assuming it
was errant in the specification.