### PR TITLE
Fix broken link to hashing a transaction

### DIFF
--- a/v2/v2-specification.md
+++ b/v2/v2-specification.md
@@ -1365,7 +1365,7 @@ bytes32 EIP712_DOMAIN_HASH = keccak256(abi.encodePacked(
 ));
 ```
 
-For more information about how this is used, see [hashing an order](#hashing-an-order) and [hashing a transaction](#hashing-a-transaction).
+For more information about how this is used, see [hashing an order](#hashing-an-order) and [hash of a transaction](#hash-of-a-transaction).
 
 ## Optimizing calldata
 


### PR DESCRIPTION
The link is "#hash-of-a-transaction" and not "#hashing-a-transaction"

Alternatively, the header could be changed, but that's would break anyone who has already linked the page.